### PR TITLE
Fix a typo

### DIFF
--- a/module/program/module.py
+++ b/module/program/module.py
@@ -1935,7 +1935,7 @@ def process_in_dir(i):
        dtags=vcmd.get('dataset_tags',[])
 
        # Check if need to add dataset file as JSON to run_vars
-       adfe=vcmd.get('add_datatset_file_to_env','')
+       adfe=vcmd.get('add_dataset_file_to_env','')
 
        edtags=i.get('extra_dataset_tags', [])
        if len(dtags)>0 and len(edtags)>0:


### PR DESCRIPTION
Hi,

This PR fixes a typo: `add_datatset_file_to_env` -> `add_dataset_file_to_env`