### PR TITLE
bugfix:invalid literal for int() with base 10: '"loop alignment."'

### DIFF
--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -355,6 +355,8 @@ def extract_opts(i):
                                    jj=exp[j].strip()
                                    if jj.find('*')>0 or jj.find('_')>0:
                                       skip=True
+                                   elif jj.rfind('\"') != -1:
+                                      continue
                                    else:
                                       jj=int(exp[j].strip())
                                       exp[j]=jj


### PR DESCRIPTION
$ ck extract_opts compiler
......
Adding param 72 "unlikely-bb-count-fraction" - The minimum fraction of profile runs a given basic block execution count must be not to be considered unlikely.
Adding param 73 "align-threshold" - Select fraction of the maximal frequency of executions of basic block in function given basic block get alignment.
Traceback (most recent call last):
  File "/media/B/git/ck/ck/kernel.py", line 9615, in <module>
    r=access(sys.argv[1:])
  File "/media/B/git/ck/ck/kernel.py", line 9571, in access
    rr=perform_action(i)
  File "/media/B/git/ck/ck/kernel.py", line 3461, in perform_action
    return a(i)
  File "/media/B/tsp/CK/ck-autotuning/module/compiler/module.py", line 360, in extract_opts
    jj=int(exp[j].strip())
ValueError: invalid literal for int() with base 10: '"loop alignment."'

the gcc/params.def file is:
DEFPARAM (PARAM_ALIGN_LOOP_ITERATIONS,
          "align-loop-iterations",
          "Loops iterating at least selected number of iterations will get "
          "loop alignment.", 4, 0, 0)

so we need to deal with it to avoid this problem.