### PR TITLE
Throw an error before working long hours

### DIFF
--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -663,6 +663,10 @@ def extract_opts_new(i):
         if add and opt!='':
            iopt+=1
 
+           opt=opt[1:]
+           if opt.startswith('fno-'):
+              opt=opt[4:]
+
            ck.out('Adding opt '+str(iopt)+' "'+opt+'" - '+desc)
 
            dd['##'+opt]={

--- a/module/pipeline/module.py
+++ b/module/pipeline/module.py
@@ -322,6 +322,9 @@ def autotune(i):
     fdfi=ck.get_from_dicts(ic, 'flat_dict_for_improvements', {}, None)
 
     record=ck.get_from_dicts(ic, 'record', '', None)
+    if record=='yes' and len(meta)==0:
+       return {'return':1, 'error':'meta is not defined - can\'t aggregate'}
+
     record_uoa=ck.get_from_dicts(ic, 'record_uoa', '', None)
     record_repo=ck.get_from_dicts(ic, 'record_repo', '', None)
     record_experiment_repo=ck.get_from_dicts(ic, 'record_experiment_repo', '', None)


### PR DESCRIPTION
We test according to the method described in the documentation(https://github.com/ctuning/ck/wiki/Autotuning).
1) $ rm _setup_program_pipeline_tmp.json
2) $ ck pipeline program:cbench-automotive-susan --cmd_key=edges --compiler_description_uoa=gcc-44x --prepare --save_to_file=_setup_program_pipeline_tmp.json
3) $ ck autotune pipeline:program pipeline_from_file=_setup_program_pipeline_tmp.json  record=yes

The program runs for a while, but at the end, this error occurs:
CK error: [pipeline] meta is not defined - can't aggregate!

We may probably throw the error earlier.