### PR TITLE
bugfix: invalid literal for int() with base 10: '"loop alignment."'

### DIFF
--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -729,6 +729,8 @@ def extract_opts_new(i):
                jj=exp[j].strip()
                if jj.find('*')>0 or jj.find('_')>0:
                   skip=True
+               elif jj.rfind('\"') != -1:
+                  continue
                else:
                   jj=int(exp[j].strip())
                   exp[j]=jj


### PR DESCRIPTION
$ ck extract_opts_new  compiler
......
Traceback (most recent call last):
  File "/home/wenyang/anaconda3/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/home/wenyang/anaconda3/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/wenyang/anaconda3/lib/python3.6/site-packages/ck/kernel.py", line 9640, in <module>
    r=access(sys.argv[1:])
  File "/home/wenyang/anaconda3/lib/python3.6/site-packages/ck/kernel.py", line 9596, in access
    rr=perform_action(i)
  File "/home/wenyang/anaconda3/lib/python3.6/site-packages/ck/kernel.py", line 3457, in perform_action
    return a(i)
  File "/home/wenyang/CK/ck-autotuning/module/compiler/module.py", line 736, in extract_opts_new
    jj=int(exp[j].strip())
ValueError: invalid literal for int() with base 10: '"loop alignment."'

the gcc/params.def file is:
DEFPARAM (PARAM_ALIGN_LOOP_ITERATIONS,
          "align-loop-iterations",
          "Loops iterating at least selected number of iterations will get "
          "loop alignment.", 4, 0, 0)

We get around this by skipping the extra strings.