### PR TITLE
bugfix: invalid literal for int() with base 10: '"loop alignment."'

### DIFF
--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -349,7 +349,9 @@ def extract_opts(i):
                                e2=0
 
                                exp=line[:-1].split(',')
-                               exp = list(filter(lambda x: x.rfind('\"') == -1, exp))
+                               for x in exp[:]:
+                                   if (x.rfind('\"') != -1):
+                                      exp.remove(x)
 
                                skip=False
                                for j in range(0, len(exp)):
@@ -722,7 +724,9 @@ def extract_opts_new(i):
            e2=0
 
            exp=line[:-1].split(',')
-           exp = list(filter(lambda x: x.rfind('\"') == -1, exp))
+           for x in exp[:]:
+               if (x.rfind('\"') != -1):
+                  exp.remove(x)
 
            skip=False
            for j in range(0, len(exp)):

--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -729,6 +729,8 @@ def extract_opts_new(i):
                jj=exp[j].strip()
                if jj.find('*')>0 or jj.find('_')>0:
                   skip=True
+               elif jj.rfind('\"') != -1:
+                  continue
                else:
                   jj=int(exp[j].strip())
                   exp[j]=jj

--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -729,8 +729,6 @@ def extract_opts_new(i):
                jj=exp[j].strip()
                if jj.find('*')>0 or jj.find('_')>0:
                   skip=True
-               elif jj.rfind('\"') != -1:
-                  continue
                else:
                   jj=int(exp[j].strip())
                   exp[j]=jj

--- a/module/compiler/module.py
+++ b/module/compiler/module.py
@@ -349,14 +349,13 @@ def extract_opts(i):
                                e2=0
 
                                exp=line[:-1].split(',')
+                               exp = list(filter(lambda x: x.rfind('\"') == -1, exp))
 
                                skip=False
                                for j in range(0, len(exp)):
                                    jj=exp[j].strip()
                                    if jj.find('*')>0 or jj.find('_')>0:
                                       skip=True
-                                   elif jj.rfind('\"') != -1:
-                                      continue
                                    else:
                                       jj=int(exp[j].strip())
                                       exp[j]=jj
@@ -723,6 +722,7 @@ def extract_opts_new(i):
            e2=0
 
            exp=line[:-1].split(',')
+           exp = list(filter(lambda x: x.rfind('\"') == -1, exp))
 
            skip=False
            for j in range(0, len(exp)):


### PR DESCRIPTION
The index is used during the for loop, so extra strings cannot be ignored.
We solve this problem by filtering out the string before the for loop.
