### PR TITLE
Provide option to redirect program output to target

### DIFF
--- a/module/program/module.py
+++ b/module/program/module.py
@@ -2822,12 +2822,25 @@ def process_in_dir(i):
              if tosd.get('remote_dir_full','')!='':
                  yrdir=tosd['remote_dir_full']+stdirs+rdir
 
-             y=rs+' '+eifsx1+tosd['change_dir']+' '+yrdir+envtsep+' '+y+eifsx1+' '+rse
+             y=rs+' '+eifsx1+tosd['change_dir']+' '+yrdir+envtsep+' '+y
+
+             # Current behaviour on android is to redirect back to the host machine.
+             # This can result in a significant amount of data transferred. On some devices
+             # this has caused the adb client to crash. Proposal is to redirect to device and
+             # transfer back as a normal run_cmd_out file.
+             # Many options for redirecting to target as all seem to be valid levels to make this choice
+             rtt=tosd.get('redirect_to_target','')=='yes' or meta.get('redirect_to_target','')=='yes' or rt.get('redirect_to_target','')=='yes'
+             if not rtt:
+                y+=eifsx1+' '+rse
 
              if cons!='yes':
                 if ercmd!='': y+=' '+ercmd
                 if rco1!='': y+=' '+stro+' '+rco1
                 if rco2!='': y+=' '+stre+' '+rco2
+
+             # Delay command end to after redirects
+             if rtt:
+                y+=eifsx1+' '+rse
 
 #             if o=='con':
 #                ck.out(y)


### PR DESCRIPTION
Currently the program redirected output for a remote deploy is written to the host machine. This has the benefit of getting the log and errors back before a target may crash. The downside is that it can send a lot of data across the remote connection (adb). We are observing the adb process crashing on the device when large amounts of data is redirected back to the host. The solution for us is to write the redirected output to the device and have it treated like a normal run output file. Note: At present the command looks like this:
adb  -s 9d37b651 shell -x "cd /data/local/tmp/tmp/; sh ./tmp-uk68egv5.sh"   > tmp-stdout.tmp 2> tmp-stderr.tmp

After the change the optional command will look like this:
adb  -s 9d37b651 shell -x "cd /data/local/tmp/tmp/; sh ./tmp-00a8jdci.sh > tmp-stdout.tmp 2> tmp-stderr.tmp"

I'm not sure if the initial design intentionally redirected back to the host. This is why I have opted to make if configurable but default to the existing behaviour. 


This also solves this issue with the existing command where the output is written to the host, no files are generated on the target and the pull back looks like this:

  (run ...)

adb  -s 9d37b651 pull /data/local/tmp/tmp/tmp-stdout.tmp tmp-stdout.tmp

adb: error: failed to stat remote object '/data/local/tmp/tmp/tmp-stdout.tmp': No such file or directory

adb  -s 9d37b651 pull /data/local/tmp/tmp/tmp-stderr.tmp tmp-stderr.tmp

adb: error: failed to stat remote object '/data/local/tmp/tmp/tmp-stderr.tmp': No such file or directory

The result of the new command looks like this:

adb  -s 9d37b651 pull /data/local/tmp/tmp/tmp-stdout.tmp tmp-stdout.tmp

/data/local/tmp/tmp/tmp-stdout.tmp: 1 file pulled. 36.2 MB/s (915988 bytes in 0.024s)

adb  -s 9d37b651 pull /data/local/tmp/tmp/tmp-stderr.tmp tmp-stderr.tmp

/data/local/tmp/tmp/tmp-stderr.tmp: 1 file pulled.
